### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/orielApp/src/drvEMC18011.cc
+++ b/orielApp/src/drvEMC18011.cc
@@ -100,9 +100,9 @@ volatile double drvEMC18011ReadbackDelay = 0.;
 /*----------------functions-----------------*/
 static int recv_mess(int card, char *com, int flag);
 static int recv_mess(int card, char *com, int flag, int recv_len);
-static RTN_STATUS send_mess(int card, char const *, char *name);
-static int send_recv_mess(int card, char const *send_com, char *recv_com);
-static int send_recv_mess(int card, char const *send_com, char *recv_com, 
+static RTN_STATUS send_mess(int card, const char *, const char *name);
+static int send_recv_mess(int card, const char *send_com, char *recv_com);
+static int send_recv_mess(int card, const char *send_com, char *recv_com, 
 			  int recv_len);
 static int set_status(int card, int signal);
 static long report(int level);
@@ -381,7 +381,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
         strncpy(send_buff, nodeptr->postmsgptr, 80);
-	send_mess(card, send_buff, (char*) NULL);
+	send_mess(card, send_buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -395,12 +395,12 @@ exit:
 /* send_receive a message to the EMC18011 board	     */
 /* send_recv_mess()		                     */
 /*****************************************************/
-static int send_recv_mess(int card, char const *send_com, char *recv_com)
+static int send_recv_mess(int card, const char *send_com, char *recv_com)
 {
   return(send_recv_mess(card, send_com, recv_com, 0));
 }
 
-static int send_recv_mess(int card, char const *send_com, char *recv_com,
+static int send_recv_mess(int card, const char *send_com, char *recv_com,
 			  int recv_len)
 {
     struct EMC18011Controller *cntrl;
@@ -459,7 +459,7 @@ static int send_recv_mess(int card, char const *send_com, char *recv_com,
 /* send a message to the EMC18011 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct EMC18011Controller *cntrl;
     int size;


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.